### PR TITLE
Load trabajos by default in Auto to improve performance

### DIFF
--- a/app/controllers/autos_controller.rb
+++ b/app/controllers/autos_controller.rb
@@ -4,8 +4,7 @@ class AutosController < ApplicationController
   active_scaffold :auto do |config|
     config.actions = [:create, :update, :list, :delete, :show, :search]
     config.label = "Remisses YA!"
-    config.columns = [:nombre, :oblea, :debe]
-    config.columns[:debe].includes = [:trabajos]
+    config.columns = [:nombre, :oblea]
     list.sorting = {:oblea => 'ASC'}
     list.columns = [:nombre, :oblea, :debe]
     list.per_page = 50

--- a/app/models/auto.rb
+++ b/app/models/auto.rb
@@ -1,7 +1,8 @@
 class Auto < ApplicationRecord
   has_many :trabajos, :dependent => :destroy
 
-  default_scope { order(oblea: :asc) }
+  # Load trabajos by default to improve performance in active_scaffold list
+  default_scope { includes(:trabajos).order(oblea: :asc) }
 
   def debe
     return "No debe nada" if trabajos_no_pagados.empty?


### PR DESCRIPTION
`Auto#trabajos` is used in each column in active_scaffold list. Including the association in the default scope removes N+1 and improves performance.

### Before
```ruby
Started GET "/autos" for ::1 at 2019-10-20 21:01:38 -0300
Processing by AutosController#index as HTML
  Auto Load (1.4ms)  SELECT  "autos".* FROM "autos" ORDER BY "autos"."oblea" ASC, "autos"."id" ASC LIMIT $1 OFFSET $2  [["LIMIT", 50], ["OFFSET", 0]]
  Trabajo Load (2.4ms)  SELECT "trabajos".* FROM "trabajos" WHERE "trabajos"."auto_id" = $1  [["auto_id", 507]]
  Trabajo Load (1.3ms)  SELECT "trabajos".* FROM "trabajos" WHERE "trabajos"."auto_id" = $1  [["auto_id", 517]]
  ... # N+1
  Trabajo Load (1.3ms)  SELECT "trabajos".* FROM "trabajos" WHERE "trabajos"."auto_id" = $1  [["auto_id", 508]]
Completed 200 OK
```

### After
```ruby
Started GET "/autos" for ::1 at 2019-10-20 21:01:38 -0300
Processing by AutosController#index as HTML
  Auto Load (1.6ms)  SELECT  "autos".* FROM "autos" ORDER BY "autos"."oblea" ASC, "autos"."id" ASC LIMIT $1 OFFSET $2  [["LIMIT", 50], ["OFFSET", 0]]
  Trabajo Load (7.8ms)  SELECT "trabajos".* FROM "trabajos" WHERE "trabajos"."auto_id" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50)  [["auto_id", 507], ["auto_id", 517], ["auto_id", 491], ["auto_id", 493], ["auto_id", 494], ["auto_id", 375], ["auto_id", 299], ["auto_id", 268], ["auto_id", 346], ["auto_id", 325], ["auto_id", 89], ["auto_id", 519], ["auto_id", 5], ["auto_id", 6], ["auto_id", 420], ["auto_id", 492], ["auto_id", 307], ["auto_id", 295], ["auto_id", 13], ["auto_id", 203], ["auto_id", 157], ["auto_id", 204], ["auto_id", 357], ["auto_id", 18], ["auto_id", 19], ["auto_id", 20], ["auto_id", 349], ["auto_id", 23], ["auto_id", 220], ["auto_id", 25], ["auto_id", 376], ["auto_id", 153], ["auto_id", 28], ["auto_id", 520], ["auto_id", 30], ["auto_id", 94], ["auto_id", 207], ["auto_id", 223], ["auto_id", 206], ["auto_id", 319], ["auto_id", 34], ["auto_id", 35], ["auto_id", 478], ["auto_id", 553], ["auto_id", 152], ["auto_id", 500], ["auto_id", 38], ["auto_id", 497], ["auto_id", 498], ["auto_id", 508]]
Completed 200 OK
```

Note: The previous approach using active_scaffold configuration to avoid N+1 was not working fine because it includes the virtual column `debe` as one of the required columns in the add/edit forms.